### PR TITLE
fix an incorrect sentence in README explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ or
 ```swift
 func show() {
   let viewController = UIViewController()
-  viewController.az_modalTransition = FashionTransition()
+  viewController.customModalTransition = FashionTransition()
   self.present(viewController, animated: true, completion: nil)
 }
 ```


### PR DESCRIPTION
I used this library to realize cool transition in my app. But at that time I found a little incorrect point in README.md, so I fixed it. 

```swift
func show() {
  let viewController = UIViewController()
  viewController.az_modalTransition = FashionTransition()
  self.present(viewController, animated: true, completion: nil)
}
```

to 

```swift
func show() {
  let viewController = UIViewController()
  viewController.customModalTransition = FashionTransition()
  self.present(viewController, animated: true, completion: nil)
}
```